### PR TITLE
chore: rename to rcloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "cloc"
+name = "rcloc"
 version = "0.6.2"
 authors = ["ltoddy <taoliu0509@gmail.com>"]
 edition = "2018"
 license = "MIT"
 readme = "README.md"
-keywords = ["cloc"]
+keywords = ["cloc","rcloc"]
 description = "Count, or compute differences of, lines of source code and comments."
 repository = "https://github.com/ltoddy/cloc-rs"
 


### PR DESCRIPTION
fix https://github.com/ltoddy/cloc-rs/issues/5