### PR TITLE
Add Terraform language

### DIFF
--- a/src/calculator.rs
+++ b/src/calculator.rs
@@ -281,6 +281,7 @@ lazy_static! {
         language!("SVG", vec!["svg"], vec![], vec![("<!--", "-->")]);
         language!("Swift", vec!["swift"], vec!["//"], vec![("/*", "*/")]);
         language!("TCL", vec!["tcl"], vec!["#"]);
+        language!("Terraform", vec!["tf", "tfvars"], vec!["#", "//"], vec![("/*", "*/")]);
         language!("TeX", vec!["tex", "sty"], vec!["%"]);
         language!("Thrift", vec!["thrift"], vec!["#", "//"], vec![("/*", "*/")]);
         language!("Toml", vec!["toml"], vec!["#"]);


### PR DESCRIPTION
Terraform supports both shell- and C-style comments, see https://developer.hashicorp.com/terraform/language/style#comments.